### PR TITLE
Add support for multi-directory albums

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ plugins:
 ```
 
 Also, you need to add [glob patterns](https://docs.python.org/3/library/glob.html#module-glob) that will be matched.
+Patterns match files relative to the root directory of the album, which is the common directory of all the albums files.
+This means that if an album has files in `albumdir/CD1` and `albumdir/CD2`, then all patterns will match relative to `albumdir`.
+
 The snippet below will add a pattern group named `all` that matches all files that have an extension.
 
 ```yaml

--- a/beetsplug/extrafiles.py
+++ b/beetsplug/extrafiles.py
@@ -141,16 +141,18 @@ class ExtraFilesPlugin(beets.plugins.BeetsPlugin):
             ),
         }
 
-        for path, category in self.find_files(
-            source,
+        sourcedir = os.path.dirname(source)
+
+        for path, category in self.match_patterns(
+            sourcedir,
             skip=self._scanned_paths,
         ):
             destpath = self.get_destination(path, category, meta.copy())
             yield path, destpath
 
-    def find_files(self, source, skip=set()):
+    def match_patterns(self, source, skip=set()):
         """Find all files matched by the patterns."""
-        source_path = beets.util.displayable_path(os.path.dirname(source))
+        source_path = beets.util.displayable_path(source)
 
         if source_path in skip:
             return

--- a/beetsplug/extrafiles.py
+++ b/beetsplug/extrafiles.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 """beets-extrafiles plugin for beets."""
 import glob
+import itertools
 import os
 import shutil
+import sys
 import traceback
 
 import beets.dbcore.db
@@ -11,6 +13,25 @@ import beets.mediafile
 import beets.plugins
 import beets.ui
 import beets.util.functemplate
+
+
+def commonpath(paths):
+    """Find longest common sub-path of each path in the sequence paths."""
+    # Typecast to list needed for Python version < 3.6
+    paths = list(paths)
+    if sys.version_info >= (3, 5):
+        return os.path.commonpath(paths)
+    else:
+        # os.path.commonpath does not exist in Python < 3.5
+        prefix = os.path.commonprefix(paths)
+
+        sep = os.sep.encode() if isinstance(prefix, bytes) else os.sep
+        prefix_split = prefix.split(sep)
+        path_split = paths[0].split(sep)
+        if path_split[:len(prefix_split)] != prefix_split:
+            prefix = os.path.dirname(prefix)
+
+        return prefix
 
 
 class FormattedExtraFileMapping(beets.dbcore.db.FormattedMapping):
@@ -51,8 +72,8 @@ class ExtraFilesPlugin(beets.plugins.BeetsPlugin):
         """Initialize a new plugin instance."""
         super(ExtraFilesPlugin, self).__init__(*args, **kwargs)
 
-        self._move_files = set()
-        self._copy_files = set()
+        self._moved_items = set()
+        self._copied_items = set()
         self._scanned_paths = set()
         self.path_formats = beets.ui.get_path_formats(self.config['paths'])
 
@@ -62,20 +83,19 @@ class ExtraFilesPlugin(beets.plugins.BeetsPlugin):
 
     def on_item_moved(self, item, source, destination):
         """Run this listener function on item_moved events."""
-        self._move_files.update(
-            set(self.gather_tasks(item, source, destination)),
-        )
+        self._moved_items.add((item, source, destination))
 
     def on_item_copied(self, item, source, destination):
         """Run this listener function on item_copied events."""
-        self._copy_files.update(
-            set(self.gather_tasks(item, source, destination)),
-        )
+        self._copied_items.add((item, source, destination))
 
     def on_cli_exit(self, lib):
         """Run this listener function when the CLI exits."""
-        self.process_files(self._copy_files, action=self._copy_file)
-        self.process_files(self._move_files, action=self._move_file)
+        files = self.gather_files(self._copied_items)
+        self.process_items(files, action=self._copy_file)
+
+        files = self.gather_files(self._moved_items)
+        self.process_items(files, action=self._move_file)
 
     def _copy_file(self, path, dest):
         """Copy path to dest."""
@@ -102,7 +122,7 @@ class ExtraFilesPlugin(beets.plugins.BeetsPlugin):
         self._log.info('Moving extra file: {0} -> {0}', path, dest)
         shutil.move(path, dest)
 
-    def process_files(self, files, action):
+    def process_items(self, files, action):
         """Move path to dest."""
         # Skip files that were moved by other plugins
         skipped_files = set()
@@ -130,25 +150,36 @@ class ExtraFilesPlugin(beets.plugins.BeetsPlugin):
                     destination,
                 )
 
-    def gather_tasks(self, item, source, destination):
-        """Generate a sequence of (path, destpath) tuples for an item."""
-        meta = {
-            'artist': item.artist or u'None',
-            'albumartist': item.albumartist or u'None',
-            'album': item.album or u'None',
-            'albumpath': beets.util.displayable_path(
-                os.path.dirname(destination),
-            ),
-        }
+    def gather_files(self, itemops):
+        """Generate a sequence of (path, destpath) tuples."""
+        def group(itemop):
+            item = itemop[0]
+            return (item.albumartist or item.artist, item.album)
 
-        sourcedir = os.path.dirname(source)
+        sorted_itemops = sorted(itemops, key=group)
+        for _, itemopgroup in itertools.groupby(sorted_itemops, key=group):
+            items, sources, destinations = zip(*itemopgroup)
+            item = items[0]
 
-        for path, category in self.match_patterns(
-            sourcedir,
-            skip=self._scanned_paths,
-        ):
-            destpath = self.get_destination(path, category, meta.copy())
-            yield path, destpath
+            sourcedirs = set(os.path.dirname(f) for f in sources)
+            destdirs = set(os.path.dirname(f) for f in destinations)
+
+            source = commonpath(sourcedirs)
+            destination = commonpath(destdirs)
+
+            meta = {
+                'artist': item.artist or u'None',
+                'albumartist': item.albumartist or u'None',
+                'album': item.album or u'None',
+                'albumpath': beets.util.displayable_path(destination),
+            }
+
+            for path, category in self.match_patterns(
+                source,
+                skip=self._scanned_paths,
+            ):
+                destpath = self.get_destination(path, category, meta.copy())
+                yield path, destpath
 
     def match_patterns(self, source, skip=set()):
         """Find all files matched by the patterns."""

--- a/tests/test_extrafiles.py
+++ b/tests/test_extrafiles.py
@@ -61,19 +61,21 @@ class BaseTestCase(unittest.TestCase):
         self.dstdir.cleanup()
 
 
-class FindPathsTestCase(BaseTestCase):
-    """Testcase that checks if all extra files are found."""
+class MatchPatternsTestCase(BaseTestCase):
+    """Testcase that checks if all extra files are matched."""
 
-    def testFindPaths(self):
-        """Test if extra files are found in the media file's directory."""
-        files = set(self.plugin.find_files(
-            source=os.path.join(self.srcdir.name, 'file.mp3'),
-        ))
+    def testMatchPattern(self):
+        """Test if extra files are matched in the media file's directory."""
+        sourcedir = self.srcdir.name
+        files = set(
+            (beets.util.displayable_path(path), category)
+            for path, category in self.plugin.match_patterns(source=sourcedir)
+        )
 
         expected_files = set([
-            (os.path.join(self.srcdir.name, 'scans/'), 'artwork'),
-            (os.path.join(self.srcdir.name, 'file.cue'), 'cue'),
-            (os.path.join(self.srcdir.name, 'file.log'), 'log'),
+            (os.path.join(sourcedir, 'scans/'), 'artwork'),
+            (os.path.join(sourcedir, 'file.cue'), 'cue'),
+            (os.path.join(sourcedir, 'file.log'), 'log'),
         ])
 
         assert files == expected_files

--- a/tests/test_extrafiles.py
+++ b/tests/test_extrafiles.py
@@ -29,26 +29,31 @@ class BaseTestCase(unittest.TestCase):
         },
     }
 
+    def _create_example_files(self, directory):
+        for filename in ('file.cue', 'file.txt', 'file.log'):
+            open(os.path.join(directory, filename), mode='w').close()
+
+        artwork_path = os.path.join(directory, 'scans')
+        os.mkdir(artwork_path)
+        for filename in ('front.jpg', 'back.jpg'):
+            open(os.path.join(artwork_path, filename), mode='w').close()
+
     def setUp(self):
         """Set up example files and instanciate the plugin."""
         self.srcdir = tempfile.TemporaryDirectory(suffix='src')
         self.dstdir = tempfile.TemporaryDirectory(suffix='dst')
-        for filename in ('file.cue', 'file.txt', 'file.log'):
-            open(os.path.join(self.srcdir.name, filename), mode='w').close()
 
+        # Create example files
         shutil.copy(
             os.path.join(RSRC, 'full.mp3'),
             os.path.join(self.srcdir.name, 'file.mp3'),
         )
+        self._create_example_files(self.srcdir.name)
 
+        # Set up plugin instance
         config = beets.util.confit.RootView(sources=[
             beets.util.confit.ConfigSource.of(self.PLUGIN_CONFIG),
         ])
-
-        artwork_path = os.path.join(self.srcdir.name, 'scans')
-        os.mkdir(artwork_path)
-        for filename in ('front.jpg', 'back.jpg'):
-            open(os.path.join(artwork_path, filename), mode='w').close()
 
         with unittest.mock.patch(
                 'beetsplug.extrafiles.beets.plugins.beets.config', config,

--- a/tests/test_extrafiles.py
+++ b/tests/test_extrafiles.py
@@ -43,12 +43,14 @@ class BaseTestCase(unittest.TestCase):
         self.srcdir = tempfile.TemporaryDirectory(suffix='src')
         self.dstdir = tempfile.TemporaryDirectory(suffix='dst')
 
-        # Create example files
+        # Create example files for single directory album
+        os.makedirs(os.path.join(self.srcdir.name, 'single'))
+        os.makedirs(os.path.join(self.dstdir.name, 'single'))
         shutil.copy(
             os.path.join(RSRC, 'full.mp3'),
-            os.path.join(self.srcdir.name, 'file.mp3'),
+            os.path.join(self.srcdir.name, 'single', 'file.mp3'),
         )
-        self._create_example_files(self.srcdir.name)
+        self._create_example_files(os.path.join(self.srcdir.name, 'single'))
 
         # Set up plugin instance
         config = beets.util.confit.RootView(sources=[
@@ -71,7 +73,7 @@ class MatchPatternsTestCase(BaseTestCase):
 
     def testMatchPattern(self):
         """Test if extra files are matched in the media file's directory."""
-        sourcedir = self.srcdir.name
+        sourcedir = os.path.join(self.srcdir.name, 'single')
         files = set(
             (beets.util.displayable_path(path), category)
             for path, category in self.plugin.match_patterns(source=sourcedir)
@@ -89,76 +91,82 @@ class MatchPatternsTestCase(BaseTestCase):
 class MoveFilesTestCase(BaseTestCase):
     """Testcase that moves files."""
 
-    def testMoveFiles(self):
-        """Test if extra files are detected an moved correctly."""
-        source = os.path.join(self.srcdir.name, 'file.mp3')
-        destination = os.path.join(self.dstdir.name, 'moved_file.mp3')
+    def testMoveFilesSingle(self):
+        """Test if extra files are moved for single directory imports."""
+        sourcedir = os.path.join(self.srcdir.name, 'single')
+        destdir = os.path.join(self.dstdir.name, 'single')
 
+        # Move file
+        source = os.path.join(sourcedir, 'file.mp3')
+        destination = os.path.join(destdir, 'moved_file.mp3')
         item = beets.library.Item.from_path(source)
         shutil.move(source, destination)
-
         self.plugin.on_item_moved(
             item, beets.util.bytestring_path(source),
             beets.util.bytestring_path(destination),
         )
+
         self.plugin.on_cli_exit(None)
 
         # Check source directory
-        assert os.path.exists(os.path.join(self.srcdir.name, 'file.txt'))
-        assert not os.path.exists(os.path.join(self.srcdir.name, 'file.cue'))
-        assert not os.path.exists(os.path.join(self.srcdir.name, 'file.log'))
-        assert not os.path.exists(os.path.join(self.srcdir.name, 'audio.log'))
+        assert os.path.exists(os.path.join(sourcedir, 'file.txt'))
+        assert not os.path.exists(os.path.join(sourcedir, 'file.cue'))
+        assert not os.path.exists(os.path.join(sourcedir, 'file.log'))
+        assert not os.path.exists(os.path.join(sourcedir, 'audio.log'))
 
-        assert not os.path.exists(os.path.join(self.srcdir.name, 'artwork'))
-        assert not os.path.exists(os.path.join(self.srcdir.name, 'scans'))
+        assert not os.path.exists(os.path.join(sourcedir, 'artwork'))
+        assert not os.path.exists(os.path.join(sourcedir, 'scans'))
 
         # Check destination directory
-        assert not os.path.exists(os.path.join(self.dstdir.name, 'file.txt'))
-        assert os.path.exists(os.path.join(self.dstdir.name, 'file.cue'))
-        assert not os.path.exists(os.path.join(self.dstdir.name, 'file.log'))
-        assert os.path.exists(os.path.join(self.dstdir.name, 'audio.log'))
+        assert not os.path.exists(os.path.join(destdir, 'file.txt'))
+        assert os.path.exists(os.path.join(destdir, 'file.cue'))
+        assert not os.path.exists(os.path.join(destdir, 'file.log'))
+        assert os.path.exists(os.path.join(destdir, 'audio.log'))
 
-        assert not os.path.isdir(os.path.join(self.dstdir.name, 'scans'))
-        assert os.path.isdir(os.path.join(self.dstdir.name, 'artwork'))
-        assert (set(os.listdir(os.path.join(self.dstdir.name, 'artwork'))) ==
+        assert not os.path.isdir(os.path.join(destdir, 'scans'))
+        assert os.path.isdir(os.path.join(destdir, 'artwork'))
+        assert (set(os.listdir(os.path.join(destdir, 'artwork'))) ==
                 set(('front.jpg', 'back.jpg')))
 
 
 class CopyFilesTestCase(BaseTestCase):
     """Testcase that copies files."""
 
-    def testCopyFiles(self):
-        """Test if files are detected and copied correctly."""
-        source = os.path.join(self.srcdir.name, 'file.mp3')
-        destination = os.path.join(self.dstdir.name, 'moved_file.mp3')
+    def testCopyFilesSingle(self):
+        """Test if extra files are copied for single directory imports."""
+        sourcedir = os.path.join(self.srcdir.name, 'single')
+        destdir = os.path.join(self.dstdir.name, 'single')
 
+        # Copy file
+        source = os.path.join(sourcedir, 'file.mp3')
+        destination = os.path.join(destdir, 'copied_file.mp3')
         item = beets.library.Item.from_path(source)
         shutil.copy(source, destination)
-
         self.plugin.on_item_copied(
             item, beets.util.bytestring_path(source),
             beets.util.bytestring_path(destination),
         )
+
         self.plugin.on_cli_exit(None)
 
         # Check source directory
-        assert os.path.exists(os.path.join(self.srcdir.name, 'file.txt'))
-        assert os.path.exists(os.path.join(self.srcdir.name, 'file.cue'))
-        assert os.path.exists(os.path.join(self.srcdir.name, 'file.log'))
-        assert not os.path.exists(os.path.join(self.srcdir.name, 'audio.log'))
+        assert os.path.exists(os.path.join(sourcedir, 'file.txt'))
+        assert os.path.exists(os.path.join(sourcedir, 'file.cue'))
+        assert os.path.exists(os.path.join(sourcedir, 'file.log'))
+        assert not os.path.exists(os.path.join(sourcedir, 'audio.log'))
 
-        assert not os.path.exists(os.path.join(self.srcdir.name, 'artwork'))
-        assert os.path.isdir(os.path.join(self.srcdir.name, 'scans'))
-        assert (set(os.listdir(os.path.join(self.srcdir.name, 'scans'))) ==
+        assert not os.path.exists(os.path.join(sourcedir, 'artwork'))
+        assert os.path.isdir(os.path.join(sourcedir, 'scans'))
+        assert (set(os.listdir(os.path.join(sourcedir, 'scans'))) ==
                 set(('front.jpg', 'back.jpg')))
 
         # Check destination directory
-        assert not os.path.exists(os.path.join(self.dstdir.name, 'file.txt'))
-        assert os.path.exists(os.path.join(self.dstdir.name, 'file.cue'))
-        assert not os.path.exists(os.path.join(self.dstdir.name, 'file.log'))
-        assert os.path.exists(os.path.join(self.dstdir.name, 'audio.log'))
+        assert not os.path.exists(os.path.join(destdir, 'file.txt'))
+        assert os.path.exists(os.path.join(destdir, 'file.cue'))
+        assert not os.path.exists(os.path.join(destdir, 'file.log'))
+        assert os.path.exists(os.path.join(destdir, 'audio.log'))
 
-        assert not os.path.exists(os.path.join(self.dstdir.name, 'scans'))
-        assert os.path.isdir(os.path.join(self.dstdir.name, 'artwork'))
-        assert (set(os.listdir(os.path.join(self.dstdir.name, 'artwork'))) ==
+        assert not os.path.exists(os.path.join(destdir, 'scans'))
+        assert os.path.isdir(os.path.join(destdir, 'artwork'))
+        assert (set(os.listdir(os.path.join(destdir, 'artwork'))) ==
                 set(('front.jpg', 'back.jpg')))


### PR DESCRIPTION
This adds support for multi-directory albums, e.g. with a structure like this:

    albumdir
    ├── album.cue
    ├── artwork
    │  ├── back.png
    │  └── front.png
    ├── CD1
    │  ├── 01 - track.mp3
    │  └── 02 - track.mp3
    ├── CD2
    │  ├── 01 - track.mp3
    │  └── 02 - track.mp3

Patterns will now match relative to the albums root directory, not relative to each directory that contains a  media file.

For single-directory albums this won't make any difference, since the root directory is identical to the directory that contains a mediafile:

    albumdir
    ├── album.cue
    ├── artwork
    │  ├── back.png
    │  └── front.png
    ├── 01 - track.mp3
    ├── 02 - track.mp3
