### PR TITLE
Use mediafile instead of beets.mediafile. Fix #22.

### DIFF
--- a/beetsplug/extrafiles.py
+++ b/beetsplug/extrafiles.py
@@ -7,9 +7,9 @@ import shutil
 import sys
 import traceback
 
+import mediafile
 import beets.dbcore.db
 import beets.library
-import beets.mediafile
 import beets.plugins
 import beets.ui
 import beets.util.functemplate
@@ -209,7 +209,7 @@ class ExtraFilesPlugin(beets.plugins.BeetsPlugin):
 
                     # Skip files handled by the beets media importer
                     ext = os.path.splitext(path)[1]
-                    if len(ext) > 1 and ext[1:] in beets.mediafile.TYPES:
+                    if len(ext) > 1 and ext[1:] in mediafile.TYPES.keys():
                         continue
 
                     yield (path, category)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,10 @@ setup(
     packages=['beetsplug'],
     namespace_packages=['beetsplug'],
     test_suite='tests',
-    install_requires=['beets>=1.4.7'],
+    install_requires=[
+        'beets>=1.4.7',
+        'mediafile~=0.6.0',
+    ],
     classifiers=[
         'Topic :: Multimedia :: Sound/Audio',
         'Topic :: Multimedia :: Sound/Audio :: Players :: MP3',


### PR DESCRIPTION
The last release of beets is broken on Python 3.8 which is why the tests might fail if you are using those versions.
I tested on Python 3.7 and all were OK.
I also tested on Python 3.9 with beets master and all were OK.

Will close #22 and close #10.