### PR TITLE
Update version specifier for mediafile.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     test_suite='tests',
     install_requires=[
         'beets>=1.4.7',
-        'mediafile~=0.6.0',
+        'mediafile>=0.6.0',
     ],
     classifiers=[
         'Topic :: Multimedia :: Sound/Audio',


### PR DESCRIPTION
This allows the plugin to be installed alongside the git master version of beets.

I have tested the change locally a decent amount to make sure newer versions of `mediafile` don't cause any issues.