### PR TITLE
Fixes Holzhause/beets-extrafiles#34

### DIFF
--- a/beetsplug/extrafiles.py
+++ b/beetsplug/extrafiles.py
@@ -241,7 +241,7 @@ class ExtraFilesPlugin(beets.plugins.BeetsPlugin):
             )
 
         # Get template funcs and evaluate against mapping
-        funcs = beets.library.DefaultTemplateFunctions().functions()
+        funcs = beets.library.models.DefaultTemplateFunctions().functions()
         filepath = path_format.substitute(mapping, funcs) + fileext
 
         # Sanitize filename


### PR DESCRIPTION
Beets upstream PR #5850 split up the library.py file into multiple files.  I had to add ```models``` in order for the script to continue to run.